### PR TITLE
Act data README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ These are listed in wake-up order, with 11/12 not waking up and having passive a
 ### Winged Velociraptor
 Try to Blend in with the Dorsal Fin Gang and not be killed
 ### Sydney - Witch
-Cast's a sleeping spell during her phase on another player that player does not wake up for their phase
-(Affected player's phone vibrates and gives notification to alert them to not take their action during their phase) 
+Casts a sleeping spell on another player. That player does not wake up for their phase (more precisely they will open their eyes, see that they were put to sleep, and not perform an action). 
 ### Rachel - Klutz
 Phone Makes a noise to alert other players to her innocence
 ### Jake - I'm Right
 Shifts all players cards to the right (the exception being the Josh)
-### Austin - No you're not
+### Austin - No You're Not
 Shift all players cards to the left (the exception being the Josh)
 ### Annalise - Unsure
 Views another player's card and can decide to switch cards or not

--- a/server/README.md
+++ b/server/README.md
@@ -39,8 +39,30 @@ The following table documents the different events and their accompanying data. 
 | c_vote       | Client | Identifies the player this player wishes to vote to kill. This can be sent multiple times to change their vote. The **ID** must be provided, not the name. | `id: number`                                                                  |
 | s_results    | Server | Provides end-of-game results.                                                                                                                              | TBD                                                                           |
 
+### Identifying middle cards
+There are a few situations where players need to identify a card from the middle.. These cards will be represented by the numbers `0` (top/leftmost), `1` (middle), and `2` (bottom/rightmost).
+
 ### `s_act` data
-TBD
+| Role       | Data             | Description                                                                                                                                                   |
+|------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rachel`   | `noise: boolean` | If `noise` is `true`, play Rachel's noise (currently, it was always be true, but this is to differentiate if we ever need to send another message to Rachel). |
+| `annalise` | `role: string`   | When Annalise requests to view another player's card, this message is sent in response to reveal to her that role.                                            |
+| `isaac`    | `role: string`   | When Isaac wakes up, `role` is his *current* role.                                                                                                       |
+
+If a role is not listed, they do not need additional information and will receive the value `null` for the `data` property.
+
+#### Special cases
+##### Sleep
+If a player was put to sleep by Sydney, their data will always be `{ "sleep": true }`. They cannot act on their turn.
 
 ### `c_act` data
-TBD
+| Role       | Data            | Description                                                                                         |
+|------------|-----------------|-----------------------------------------------------------------------------------------------------|
+| `sydney`   | `id: number`    | The ID of the player she wishes to put to sleep. She cannot choose herself.                         |
+| `annalise` | `id: number`    | First sent message. The ID of the player she wishes to view the role of. She cannot choose herself. |
+| `annalise` | `swap: boolean` | Second sent message. Whether or not she wishes to swap with the player she viewed the role of.      |
+| `hannah`   | `ids: array`    | The IDs of the two players to swap cards. Neither ID can be hers.                                   |
+| `daniel`   | `card: number`  | Which card to take from the middle.                                                                 |
+| `cat`      | `card: number`  | Which card to flip over in the middle.                                                              |
+
+Annalise clarification: she sends her first message, the server responds, she sends her second message.

--- a/server/src/app/game.js
+++ b/server/src/app/game.js
@@ -21,6 +21,8 @@ class GameApp {
       this.actTimer = setTimeout(() => {
         this.actTimer = null;
 
+        // TODO: probably send `s_act` message to rachel to make noise if she is current role
+
         if(this.gameModule.hasNextRole) {
           this.nextAct();
         } else {

--- a/server/src/game/module.js
+++ b/server/src/game/module.js
@@ -80,6 +80,7 @@ class GameModule {
     console.log(`Player ${player.name} acting`);
 
     // TODO: use `data` to manipulate roles, players, etc.
+    // TODO: check if player is asleep. If so, don't do anything
 
     player.hasActed = true;
   }


### PR DESCRIPTION
Before, data was not specified for `s_act` and `c_act` WebSocket messages. This PR adds documentation for what the data should be. I also added some TODO's based off this data.